### PR TITLE
Some maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/savage13/tint"
 readme = "README.md"
 keywords = ["color", "colour", "rgb", "hsv"]
 license-file = "LICENSE"
+edition = "2018"
 
 [dependencies]
 lazy_static = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tint"
-version = "1.0.0"
+version = "1.0.2"
 authors = ["Brian Savage <savage13@gmail.com>"]
 description = "Color creation and manipulation"
 repository = "https://github.com/savage13/tint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ license-file = "LICENSE"
 edition = "2018"
 
 [dependencies]
-lazy_static = "0.2"
-
+lazy_static = "1.3.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 savage13
+Copyright (c) 2019 rusty-snake
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,15 +11,9 @@ Add this to your `Cargo.toml`:
 tint = "1.0.0"
 ```
 
-and this to your crate root:
-
-```rust
-extern crate tint;
-```
-
 ### Example
+
 ```rust
-extern crate tint;
 use tint::Color;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,17 +33,15 @@
 //! ## XKCD Colors
 //! https://xkcd.com/color/rgb/
 
-#[macro_use]
-extern crate lazy_static;
-
-use std::collections::HashMap;
-use std::fmt;
-use std::fs::File;
-use std::io::BufRead;
-use std::io::BufReader;
-use std::io::Cursor;
-use std::path::Path;
-use std::sync::Mutex;
+use lazy_static::lazy_static;
+use std::{
+    collections::HashMap,
+    fmt,
+    fs::File,
+    io::{BufRead, BufReader, Cursor},
+    path::Path,
+    sync::Mutex,
+};
 
 pub type Colour = Color;
 
@@ -77,7 +75,6 @@ impl Color {
     }
 
     // RGB 1.0
-
     /// Create new color from RGB components [0. .. 1.0],
     ///   alpha value set to 1.0
     ///
@@ -156,10 +153,11 @@ impl Color {
     /// assert_eq!(purple.to_rgb255(), (255,0,255));
     /// ```
     pub fn to_rgb255(&self) -> (u8, u8, u8) {
-        let r = (self.red * 255.0) as u8;
-        let g = (self.green * 255.0) as u8;
-        let b = (self.blue * 255.0) as u8;
-        (r, g, b)
+        (
+            (self.red * 255.0) as u8,
+            (self.green * 255.0) as u8,
+            (self.blue * 255.0) as u8,
+        )
     }
 
     // HEX
@@ -373,7 +371,7 @@ impl<'a> From<&'a Vec<f32>> for Color {
         Color::from(&c64)
     }
 }
-/// Convert from a f32 Vec, red, green, blue, maybe alpha
+/// Convert from a f64 Vec, red, green, blue, maybe alpha
 ///
 /// This may fail
 impl From<Vec<f64>> for Color {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,12 +550,14 @@ pub fn compare_by_hsv(a: &Color, b: &Color) -> std::cmp::Ordering {
 
 // https://en.wikipedia.org/wiki/YIQ#From_RGB_to_YIQ
 // FCC NTSC Standard
+#[allow(clippy::many_single_char_names)]
 fn rgb2yiq(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
     let y = 0.30 * r + 0.59 * g + 0.11 * b;
     let i = 0.74 * (r - y) - 0.27 * (b - y);
     let q = 0.48 * (r - y) + 0.41 * (b - y);
     (y, i, q)
 }
+#[allow(clippy::many_single_char_names)]
 fn yiq2rgb(y: f64, i: f64, q: f64) -> (f64, f64, f64) {
     let v33 = 1.709_006_928_406_466_6;
     let v32 = -1.108_545_034_642_032_2;
@@ -593,6 +595,7 @@ fn fmax(v: &[f64]) -> f64 {
 /// h : [0, 360]
 /// s : [0, 1]
 /// v : [0, 1]
+#[allow(clippy::many_single_char_names)]
 fn rgb2hsv(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
     let cmax = fmax(&[r, g, b]);
     let cmin = fmin(&[r, g, b]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,7 @@ impl PartialEq for Color {
 }
 
 impl fmt::Display for Color {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "({:5.3}, {:5.3}, {:5.3}, {:5.3})",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-
 //! Color creation and manipulation
 //!
 //! ```
@@ -34,24 +33,22 @@
 //! ## XKCD Colors
 //! https://xkcd.com/color/rgb/
 
-
 #[macro_use]
 extern crate lazy_static;
 
 use std::collections::HashMap;
-use std::sync::Mutex;
-use std::io::Cursor;
 use std::fmt;
 use std::fs::File;
-use std::io::BufReader;
 use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Cursor;
 use std::path::Path;
-
+use std::sync::Mutex;
 
 pub type Colour = Color;
 
 /// Color value
-#[derive(Debug,Copy,Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Color {
     /// Red component [0,1]
     pub red: f64,
@@ -71,7 +68,12 @@ impl Color {
     /// let fushcia = Color::new(1.0, 0.0, 1.0, 1.0);
     /// ```
     pub fn new(red: f64, green: f64, blue: f64, alpha: f64) -> Color {
-        Color { red: red, green: green, blue: blue, alpha: alpha }
+        Color {
+            red: red,
+            green: green,
+            blue: blue,
+            alpha: alpha,
+        }
     }
 
     // RGB 1.0
@@ -84,7 +86,12 @@ impl Color {
     /// let blue = Color::from_rgb1(0.0, 0.0, 1.0);
     /// ```
     pub fn from_rgb1(r: f64, g: f64, b: f64) -> Color {
-        Color { red: r, green: g, blue: b, alpha: 1.0 }
+        Color {
+            red: r,
+            green: g,
+            blue: b,
+            alpha: 1.0,
+        }
     }
     /// Create new color from RGB f64 vector [0. .. 1.0],
     ///   alpha value set to 1.0
@@ -94,9 +101,14 @@ impl Color {
     /// let green = Color::from_rgb1v(&[0.0, 1.0, 0.0]);
     /// ```
     pub fn from_rgb1v(rgb: &[f64]) -> Color {
-        Color { red: rgb[0], green: rgb[1], blue: rgb[2], alpha: 1.0 }
+        Color {
+            red: rgb[0],
+            green: rgb[1],
+            blue: rgb[2],
+            alpha: 1.0,
+        }
     }
-    /// Convert Color to (f64,f64,f64) 
+    /// Convert Color to (f64,f64,f64)
     ///
     /// ```
     /// # use tint::Color;
@@ -104,10 +116,9 @@ impl Color {
     /// let rgb = purple.to_rgb1();
     /// assert_eq!(rgb, (1.0, 0.0, 1.0));
     /// ```
-    pub fn to_rgb1(&self) -> (f64,f64,f64) {
+    pub fn to_rgb1(&self) -> (f64, f64, f64) {
         (self.red, self.green, self.blue)
     }
-
 
     // RGB 255
     /// Create new Color from RGB [0 .. 255]
@@ -118,9 +129,11 @@ impl Color {
     /// let purple = Color::from_rgb255(255, 0, 255);
     /// ```
     pub fn from_rgb255(red: u8, green: u8, blue: u8) -> Color {
-        Color::from_rgb1((red as f64)/255.,
-                         (green as f64)/255.,
-                         (blue as f64)/255.)
+        Color::from_rgb1(
+            (red as f64) / 255.,
+            (green as f64) / 255.,
+            (blue as f64) / 255.,
+        )
     }
     /// Create new Color from RGB u8 vector [0 .. 255]
     ///   alpha value set to 1.0
@@ -142,11 +155,11 @@ impl Color {
     /// let purple = Color::new(1.0, 0.0, 1.0, 1.0);
     /// assert_eq!(purple.to_rgb255(), (255,0,255));
     /// ```
-    pub fn to_rgb255(&self) -> (u8,u8,u8) {
-        let r = (self.red   * 255.0) as u8;
+    pub fn to_rgb255(&self) -> (u8, u8, u8) {
+        let r = (self.red * 255.0) as u8;
         let g = (self.green * 255.0) as u8;
-        let b = (self.blue  * 255.0) as u8;
-        (r,g,b)
+        let b = (self.blue * 255.0) as u8;
+        (r, g, b)
     }
 
     // HEX
@@ -158,11 +171,15 @@ impl Color {
     /// assert_eq!(facade.to_rgb255(), (250, 202, 222));
     /// ```
     pub fn from_hex(hex: &str) -> Color {
-        let n = if hex.chars().nth(0).unwrap() == '#' { 1 } else { 0 };
-        let r = u8::from_str_radix(&hex[n+0..n+2],16).unwrap();
-        let g = u8::from_str_radix(&hex[n+2..n+4],16).unwrap();
-        let b = u8::from_str_radix(&hex[n+4..n+6],16).unwrap();
-        Color::from_rgb255(r,g,b)
+        let n = if hex.chars().nth(0).unwrap() == '#' {
+            1
+        } else {
+            0
+        };
+        let r = u8::from_str_radix(&hex[n + 0..n + 2], 16).unwrap();
+        let g = u8::from_str_radix(&hex[n + 2..n + 4], 16).unwrap();
+        let b = u8::from_str_radix(&hex[n + 4..n + 6], 16).unwrap();
+        Color::from_rgb255(r, g, b)
     }
     /// Convert Color into Hex String
     ///
@@ -172,8 +189,8 @@ impl Color {
     /// assert_eq!(coffee.to_hex(), "#c0ffee");
     /// ```
     pub fn to_hex(&self) -> String {
-        let (r,g,b) = self.to_rgb255();
-        format!("#{:02x}{:02x}{:02x}", r,g,b)
+        let (r, g, b) = self.to_rgb255();
+        format!("#{:02x}{:02x}{:02x}", r, g, b)
     }
     //pub fn from_hexs(hex: &str) -> Vec<Color> {
     //    hex.split(',').map(|x| Color::from_hex(x)).collect()
@@ -207,36 +224,36 @@ impl Color {
 
     // HSV
     /// Convert Color to HSV
-    pub fn to_hsv(&self) -> (f64,f64,f64) {
+    pub fn to_hsv(&self) -> (f64, f64, f64) {
         rgb2hsv(self.red, self.green, self.blue)
     }
     /// Create new Color from HSV
     ///   alpha value set to 1.0
     pub fn from_hsv(&self) -> Color {
-        let (r,g,b) = hsv2rgb(self.red, self.green, self.blue);
-        Color::new(r,g,b,1.0)
+        let (r, g, b) = hsv2rgb(self.red, self.green, self.blue);
+        Color::new(r, g, b, 1.0)
     }
     // HSL
     /// Convert Color to HSL
-    pub fn to_hsl(&self) -> (f64,f64,f64) {
+    pub fn to_hsl(&self) -> (f64, f64, f64) {
         rgb2hsl(self.red, self.green, self.blue)
     }
     /// Create new Color from HSL
     ///   alpha value set to 1.0
     pub fn from_hsl(&self) -> Color {
-        let (r,g,b) = hsl2rgb(self.red, self.green, self.blue);
-        Color::new(r,g,b,1.0)
+        let (r, g, b) = hsl2rgb(self.red, self.green, self.blue);
+        Color::new(r, g, b, 1.0)
     }
     // YIQ
     /// Convert Color to YIQ
-    pub fn to_yiq(&self) -> (f64,f64,f64) {
+    pub fn to_yiq(&self) -> (f64, f64, f64) {
         rgb2yiq(self.red, self.green, self.blue)
     }
     /// Create new Color from YIQ
     ///   alpha value set to 1.0
     pub fn from_yiq(&self) -> Color {
-        let (r,g,b) = yiq2rgb(self.red, self.green, self.blue);
-        Color::new(r,g,b,1.0)
+        let (r, g, b) = yiq2rgb(self.red, self.green, self.blue);
+        Color::new(r, g, b, 1.0)
     }
 }
 
@@ -249,87 +266,87 @@ impl From<String> for Color {
     fn from(s: String) -> Color {
         match Color::name(&s) {
             None => Color::from_hex(&s),
-            Some(c) => c
+            Some(c) => c,
         }
     }
 }
 /// Convert from named color or a hex string
 ///
 /// This may fail
-impl <'a> From<&'a String> for Color {
+impl<'a> From<&'a String> for Color {
     fn from(s: &'a String) -> Color {
         match Color::name(s) {
             None => Color::from_hex(s),
-            Some(c) => c
+            Some(c) => c,
         }
     }
 }
 /// Convert from named color or a hex string
 ///
 /// This may fail
-impl <'a> From<&'a str> for Color {
+impl<'a> From<&'a str> for Color {
     fn from(s: &'a str) -> Color {
         match Color::name(s) {
             None => Color::from_hex(s),
-            Some(c) => c
+            Some(c) => c,
         }
     }
 }
 
 // Tuples
 /// Convert from a u8 triple, red, green, blue
-impl From<(u8,u8,u8)> for Color {
-    fn from(c: (u8,u8,u8)) -> Color {
+impl From<(u8, u8, u8)> for Color {
+    fn from(c: (u8, u8, u8)) -> Color {
         Color::from_rgb255(c.0, c.1, c.2)
     }
 }
 /// Convert from a f64 triple, red, green, blue
-impl From<(f64,f64,f64)> for Color {
-    fn from(c: (f64,f64,f64)) -> Color {
+impl From<(f64, f64, f64)> for Color {
+    fn from(c: (f64, f64, f64)) -> Color {
         Color::from_rgb1(c.0, c.1, c.2)
     }
 }
 /// Convert from a f32 triple, red, green, blue
-impl From<(f32,f32,f32)> for Color {
-    fn from(c: (f32,f32,f32)) -> Color {
+impl From<(f32, f32, f32)> for Color {
+    fn from(c: (f32, f32, f32)) -> Color {
         Color::from_rgb1(c.0 as f64, c.1 as f64, c.2 as f64)
     }
 }
 
 // Arrays
 /// Convert from a u8 triple, red, green, blue
-impl <'a> From<&'a [u8;3]> for Color {
-    fn from(c: &'a [u8;3]) -> Color {
+impl<'a> From<&'a [u8; 3]> for Color {
+    fn from(c: &'a [u8; 3]) -> Color {
         Color::from_rgb255v(c)
     }
 }
 /// Convert from a f64 triple, red, green, blue
-impl <'a> From<&'a [f64;3]> for Color {
-    fn from(c: &'a [f64;3]) -> Color {
+impl<'a> From<&'a [f64; 3]> for Color {
+    fn from(c: &'a [f64; 3]) -> Color {
         Color::from_rgb1v(c)
     }
 }
 /// Convert from a f32 triple, red, green, blue
-impl <'a> From<&'a [f32;3]> for Color {
-    fn from(c: &'a [f32;3]) -> Color {
+impl<'a> From<&'a [f32; 3]> for Color {
+    fn from(c: &'a [f32; 3]) -> Color {
         Color::new(c[0] as f64, c[1] as f64, c[2] as f64, 1.0)
     }
 }
 /// Convert from a u8 triple, red, green, blue
-impl From<[u8;3]> for Color {
-    fn from(c: [u8;3]) -> Color {
+impl From<[u8; 3]> for Color {
+    fn from(c: [u8; 3]) -> Color {
         Color::from_rgb255v(&c)
     }
 }
 /// Convert from a f64 triple, red, green, blue
-impl From<[f64;3]> for Color {
-    fn from(c: [f64;3]) -> Color {
+impl From<[f64; 3]> for Color {
+    fn from(c: [f64; 3]) -> Color {
         Color::from_rgb1v(&c)
     }
 }
 /// Convert from a f32 triple, red, green, blue
-impl From<[f32;3]> for Color {
-    fn from(c: [f32;3]) -> Color {
+impl From<[f32; 3]> for Color {
+    fn from(c: [f32; 3]) -> Color {
         Color::new(c[0] as f64, c[1] as f64, c[2] as f64, 1.0)
     }
 }
@@ -338,7 +355,7 @@ impl From<[f32;3]> for Color {
 /// Convert from a f64 Vec, red, green, blue, maybe alpha
 ///
 /// This may fail
-impl <'a> From<&'a Vec<f64>> for Color {
+impl<'a> From<&'a Vec<f64>> for Color {
     fn from(c: &'a Vec<f64>) -> Color {
         match c.len() {
             3 => Color::new(c[0], c[1], c[2], 1.0),
@@ -350,9 +367,9 @@ impl <'a> From<&'a Vec<f64>> for Color {
 /// Convert from a f32 Vec, red, green, blue, maybe alpha
 ///
 /// This may fail
-impl <'a> From<&'a Vec<f32>> for Color {
+impl<'a> From<&'a Vec<f32>> for Color {
     fn from(c: &'a Vec<f32>) -> Color {
-        let c64 : Vec<_> = c.into_iter().map(|x| *x as f64).collect();
+        let c64: Vec<_> = c.into_iter().map(|x| *x as f64).collect();
         Color::from(&c64)
     }
 }
@@ -369,37 +386,42 @@ impl From<Vec<f64>> for Color {
 /// This may fail
 impl From<Vec<f32>> for Color {
     fn from(c: Vec<f32>) -> Color {
-        let c64 : Vec<_> = c.into_iter().map(|x| x as f64).collect();
+        let c64: Vec<_> = c.into_iter().map(|x| x as f64).collect();
         Color::from(&c64)
     }
 }
 
 impl PartialEq for Color {
     fn eq(&self, other: &Color) -> bool {
-        self.red == other.red &&
-            self.blue  == other.blue &&
-            self.green == other.green &&
-            self.alpha == other.alpha
+        self.red == other.red
+            && self.blue == other.blue
+            && self.green == other.green
+            && self.alpha == other.alpha
     }
 }
 
 impl fmt::Display for Color {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "({:5.3}, {:5.3}, {:5.3}, {:5.3})", self.red, self.green, self.blue, self.alpha)
+        write!(
+            f,
+            "({:5.3}, {:5.3}, {:5.3}, {:5.3})",
+            self.red, self.green, self.blue, self.alpha
+        )
     }
 }
 
-
-
 fn parse_rgb_name(line: &str) -> Option<(String, Vec<u8>)> {
     // R G B Color Names
-    let rgb : Vec<_>= line.split_whitespace().take(3)
+    let rgb: Vec<_> = line
+        .split_whitespace()
+        .take(3)
         .map(|x| x.parse::<u8>())
         .collect();
     let is_rgb = rgb.iter().all(|x| x.is_ok());
     if is_rgb && rgb.len() == 3 {
         let rgb = rgb.into_iter().map(|x| x.unwrap()).collect::<Vec<u8>>();
-        let name = line.split_whitespace()
+        let name = line
+            .split_whitespace()
             .skip(3)
             .map(|x| x.to_owned())
             .collect::<Vec<String>>()
@@ -422,7 +444,6 @@ fn parse_name_hex(line: &str) -> Option<(String, Color)> {
     None
 }
 
-
 /// Load a buffer and return a Vec<String, Color)> of names and colors
 ///
 ///   Available formats include:
@@ -431,13 +452,14 @@ fn parse_name_hex(line: &str) -> Option<(String, Color)> {
 ///   Lines beginning with # are ignored
 
 pub fn read_buffer<T>(buf: T) -> Vec<(String, Color)>
-    where T: BufRead
+where
+    T: BufRead,
 {
     let mut out = vec![];
     for xline in buf.lines() {
         let line = xline.unwrap();
 
-        if let Some((name,rgb)) = parse_rgb_name(&line) {
+        if let Some((name, rgb)) = parse_rgb_name(&line) {
             out.push((name, Color::from_rgb255v(&rgb)));
         } else if let Some((name, color)) = parse_name_hex(&line) {
             out.push((name, color))
@@ -450,7 +472,8 @@ pub fn read_buffer<T>(buf: T) -> Vec<(String, Color)>
 
 /// Read a file and return a Vec<String, Color)> of names and colors
 pub fn read_file<P>(file: P) -> Vec<(String, Color)>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     let fp = File::open(file).unwrap();
     let fp = BufReader::new(&fp);
@@ -461,7 +484,8 @@ pub fn read_file<P>(file: P) -> Vec<(String, Color)>
 ///
 ///   Existing colors will not be overwritten and a warning will be issued.
 pub fn load_rgb_buffer<T>(buf: T)
-    where T: BufRead
+where
+    T: BufRead,
 {
     for (xname, color) in read_buffer(buf).into_iter() {
         let name = xname.to_lowercase();
@@ -476,7 +500,8 @@ pub fn load_rgb_buffer<T>(buf: T)
 ///
 ///   Existing colors will not be overwritten and a warning will be issued.
 pub fn load_rgb_file<P>(file: P)
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     let fp = File::open(file).unwrap();
     let fp = BufReader::new(&fp);
@@ -485,11 +510,11 @@ pub fn load_rgb_file<P>(file: P)
 
 lazy_static! {
     static ref COLOR_MAP: Mutex<HashMap<String, Color>> = {
-        let mut m : HashMap<String, Color> = HashMap::new();
+        let mut m: HashMap<String, Color> = HashMap::new();
         for s in [COLORS_BASIC, COLORS_EXTENDED].iter() {
-            for (ref xname, color) in read_buffer( Cursor::new( s ) ).into_iter() {
+            for (ref xname, color) in read_buffer(Cursor::new(s)).into_iter() {
                 let name = xname.to_lowercase();
-                if ! m.contains_key(&name) {
+                if !m.contains_key(&name) {
                     m.insert(name, color);
                 }
             }
@@ -508,7 +533,7 @@ pub fn names() -> Vec<String> {
     map.keys().cloned().collect()
 }
 
-fn cmp3(a: (f64,f64,f64), b:(f64,f64,f64)) -> std::cmp::Ordering {
+fn cmp3(a: (f64, f64, f64), b: (f64, f64, f64)) -> std::cmp::Ordering {
     if a.0 > b.0 {
         return std::cmp::Ordering::Greater;
     } else if a.0 < b.0 {
@@ -534,40 +559,46 @@ pub fn compare_by_rgb(a: &Color, b: &Color) -> std::cmp::Ordering {
 
 /// Compare Colors by hue, then saturation, then value
 pub fn compare_by_hsv(a: &Color, b: &Color) -> std::cmp::Ordering {
-    cmp3(a.to_hsv(),b.to_hsv())
+    cmp3(a.to_hsv(), b.to_hsv())
 }
-
-
 
 // https://en.wikipedia.org/wiki/YIQ#From_RGB_to_YIQ
 // FCC NTSC Standard
-fn rgb2yiq(r: f64, g: f64, b: f64) -> (f64,f64,f64) {
+fn rgb2yiq(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
     let y = 0.30 * r + 0.59 * g + 0.11 * b;
-    let i = 0.74 * (r-y) - 0.27 * (b-y);
-    let q = 0.48 * (r-y) + 0.41 * (b-y);
-    (y,i,q)
+    let i = 0.74 * (r - y) - 0.27 * (b - y);
+    let q = 0.48 * (r - y) + 0.41 * (b - y);
+    (y, i, q)
 }
-fn yiq2rgb(y: f64, i: f64, q:f64) -> (f64,f64,f64) {
-    let v33 =  1.7090069284064666;
+fn yiq2rgb(y: f64, i: f64, q: f64) -> (f64, f64, f64) {
+    let v33 = 1.7090069284064666;
     let v32 = -1.1085450346420322;
     let v22 = -0.27478764629897834;
     let v23 = -0.6356910791873801;
-    let v13 =  0.6235565819861433;
-    let v12 =  0.9468822170900693;
+    let v13 = 0.6235565819861433;
+    let v12 = 0.9468822170900693;
     let r = y + v12 * i + v13 * q;
     let g = y + v22 * i + v23 * q;
     let b = y + v32 * i + v33 * q;
-    (r,g,b)
+    (r, g, b)
 }
 
 fn fmin(v: &[f64]) -> f64 {
     let mut val = v[0];
-    for vi in v { if *vi < val { val = *vi; } }
+    for vi in v {
+        if *vi < val {
+            val = *vi;
+        }
+    }
     val
 }
 fn fmax(v: &[f64]) -> f64 {
     let mut val = v[0];
-    for vi in v { if *vi > val { val = *vi; } }
+    for vi in v {
+        if *vi > val {
+            val = *vi;
+        }
+    }
     val
 }
 
@@ -576,11 +607,11 @@ fn fmax(v: &[f64]) -> f64 {
 /// h : [0, 360]
 /// s : [0, 1]
 /// v : [0, 1]
-fn rgb2hsv(r: f64, g: f64, b: f64) -> (f64,f64,f64) {
-    let cmax = fmax(&[r,g,b]);
-    let cmin = fmin(&[r,g,b]);
+fn rgb2hsv(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
+    let cmax = fmax(&[r, g, b]);
+    let cmin = fmin(&[r, g, b]);
     if (cmax - cmin).abs() < 1e-5 {
-        return (0.,0.,cmax);
+        return (0., 0., cmax);
     }
     let v = cmax;
     let delta = cmax - cmin;
@@ -605,7 +636,7 @@ fn rgb2hsv(r: f64, g: f64, b: f64) -> (f64,f64,f64) {
 fn hsv2rgb(h: f64, s: f64, v: f64) -> (f64, f64, f64) {
     //println!("hsv: {} {} {}", h,s,v);
     if s <= 0.0 {
-        return (v,v,v);
+        return (v, v, v);
     }
     let mut hh = h;
     if hh >= 360.0 {
@@ -619,20 +650,20 @@ fn hsv2rgb(h: f64, s: f64, v: f64) -> (f64, f64, f64) {
     let t = v * (1.0 - (s * (1.0 - ff)));
     //println!("hsv: i {} {} {} {} {}", i, p,q,t,v);
     match i {
-        0 => (v,t,p),
-        1 => (q,v,p),
-        2 => (p,v,t),
-        3 => (p,q,v),
-        4 => (t,p,v),
-        5 => (v,p,q),
+        0 => (v, t, p),
+        1 => (q, v, p),
+        2 => (p, v, t),
+        3 => (p, q, v),
+        4 => (t, p, v),
+        5 => (v, p, q),
         _ => panic!("Unexpected value in hsv2rgb: i: {} h: {}", i, h),
     }
 }
 
 fn rgb2hsl(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
-    let cmax = fmax(&[r,g,b]);
-    let cmin = fmin(&[r,g,b]);
-    let l = (cmax + cmin)/2.0;
+    let cmax = fmax(&[r, g, b]);
+    let cmin = fmin(&[r, g, b]);
+    let l = (cmax + cmin) / 2.0;
     if (cmax - cmin).abs() <= 1e-5 {
         return (0., 0., l);
     }
@@ -641,19 +672,18 @@ fn rgb2hsl(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
     if l <= 0.5 {
         s = d / (cmax + cmin);
     }
-    let mut h =
-        if r >= cmax {
-            let dh = if g < b { 6.0 } else { 0.0 };
-            (g - b) / d + dh
-        } else if g >= cmax {
-            2.0 + (b - r) / d
-        } else if b >= cmax {
-            4.0 + (r - g) / d
-        } else {
-            0.0
-        };
+    let mut h = if r >= cmax {
+        let dh = if g < b { 6.0 } else { 0.0 };
+        (g - b) / d + dh
+    } else if g >= cmax {
+        2.0 + (b - r) / d
+    } else if b >= cmax {
+        4.0 + (r - g) / d
+    } else {
+        0.0
+    };
     h = h / 6.0;
-    (h,s,l)
+    (h, s, l)
 }
 
 fn hue2rgb(p: f64, q: f64, t: f64) -> f64 {
@@ -664,59 +694,66 @@ fn hue2rgb(p: f64, q: f64, t: f64) -> f64 {
     if tt > 1.0 {
         tt -= 1.0
     }
-    if tt < 1./6. {
+    if tt < 1. / 6. {
         return p + (q - p) * 6.0 * tt;
     }
-    if tt < 1./2. {
+    if tt < 1. / 2. {
         return q;
     }
-    if tt < 2./3. {
-        return p + (q - p) * (2./3. - tt) * 6.0;
+    if tt < 2. / 3. {
+        return p + (q - p) * (2. / 3. - tt) * 6.0;
     }
     return p;
 }
 
 fn hsl2rgb(h: f64, s: f64, l: f64) -> (f64, f64, f64) {
     if s.abs() <= 1e-5 {
-        return (l,l,l);
+        return (l, l, l);
     }
-    let q =
-        if l < 0.5 {
-            l * (1.0 + s)
-        } else {
-            l + s - (l * s)
-        };
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - (l * s)
+    };
     let p = 2.0 * l - q;
-    let r = hue2rgb(p, q, h + 1./3.);
+    let r = hue2rgb(p, q, h + 1. / 3.);
     let g = hue2rgb(p, q, h);
-    let b = hue2rgb(p, q, h - 1./3.);
-    (r,g,b)
+    let b = hue2rgb(p, q, h - 1. / 3.);
+    (r, g, b)
 }
 
 //include!("extended.rs");
 
-static COLORS_BASIC:    &'static str = include_str!("w3c_basic.txt");
+static COLORS_BASIC: &'static str = include_str!("w3c_basic.txt");
 static COLORS_EXTENDED: &'static str = include_str!("w3c_extended.txt");
-static COLORS_XKCD:     &'static str = include_str!("xkcd.txt");
-
+static COLORS_XKCD: &'static str = include_str!("xkcd.txt");
 
 #[cfg(test)]
 mod tests {
     use super::*;
     #[test]
     fn basic() {
-        assert_eq!(Color::name("black"),   Some(Color::new(0.,0.,0.,1.)));
-        assert_eq!(Color::name("white"),   Some(Color::new(1.,1.,1.,1.)));
-        assert_eq!(Color::name("red"),     Some(Color::new(1.,0.,0.,1.)));
-        assert_eq!(Color::name("green"),   Some(Color::new(0.,128./255.,0.,1.)));
-        assert_eq!(Color::name("blue"),    Some(Color::new(0.,0.,1.,1.)));
-        assert_eq!(Color::name("yellow"),  Some(Color::new(1.,1.,0.,1.)));
-        assert_eq!(Color::name("cyan"),    Some(Color::new(0.,1.,1.,1.)));
-        assert_eq!(Color::name("orange"),  Some(Color::new(1.,165./255.,0.,1.)));
-        assert_eq!(Color::name("fuchsia"), Some(Color::new(1.,0.,1.,1.)));
-        for name in ["black","silver","gray","white","maroon", "red","purple",
-                     "fuchsia","green","lime","olive","yellow","navy","blue",
-                     "teal","aqua"].iter() {
+        assert_eq!(Color::name("black"), Some(Color::new(0., 0., 0., 1.)));
+        assert_eq!(Color::name("white"), Some(Color::new(1., 1., 1., 1.)));
+        assert_eq!(Color::name("red"), Some(Color::new(1., 0., 0., 1.)));
+        assert_eq!(
+            Color::name("green"),
+            Some(Color::new(0., 128. / 255., 0., 1.))
+        );
+        assert_eq!(Color::name("blue"), Some(Color::new(0., 0., 1., 1.)));
+        assert_eq!(Color::name("yellow"), Some(Color::new(1., 1., 0., 1.)));
+        assert_eq!(Color::name("cyan"), Some(Color::new(0., 1., 1., 1.)));
+        assert_eq!(
+            Color::name("orange"),
+            Some(Color::new(1., 165. / 255., 0., 1.))
+        );
+        assert_eq!(Color::name("fuchsia"), Some(Color::new(1., 0., 1., 1.)));
+        for name in [
+            "black", "silver", "gray", "white", "maroon", "red", "purple", "fuchsia", "green",
+            "lime", "olive", "yellow", "navy", "blue", "teal", "aqua",
+        ]
+        .iter()
+        {
             assert_eq!(Color::name(name).is_some(), true);
         }
     }
@@ -743,39 +780,158 @@ mod tests {
         assert_eq!(Color::name("cyan").unwrap().to_hex(), "#00ffff");
         assert_eq!(Color::name("orange").unwrap().to_hex(), "#ffa500");
     }
-    
+
     #[test]
     fn extended() {
-        let ext_names = ["aliceblue","antiquewhite","aqua","aquamarine","azure",
-                         "beige","bisque","black","blanchedalmond","blue","blueviolet",
-                         "brown","burlywood","cadetblue","chartreuse","chocolate",
-                         "coral","cornflowerblue","cornsilk","crimson","cyan",
-                         "darkblue","darkcyan","darkgoldenrod","darkgray","darkgreen",
-                         "darkgrey","darkkhaki","darkmagenta","darkolivegreen",
-                         "darkorange","darkorchid","darkred","darksalmon",
-                         "darkseagreen","darkslateblue","darkslategray","darkslategrey",
-                         "darkturquoise","darkviolet","deeppink","deepskyblue","dimgray",
-                         "dimgrey","dodgerblue","firebrick","floralwhite","forestgreen",
-                         "fuchsia","gainsboro","ghostwhite","gold","goldenrod","gray",
-                         "green","greenyellow","grey","honeydew","hotpink","indianred",
-                         "indigo","ivory","khaki","lavender","lavenderblush","lawngreen",
-                         "lemonchiffon","lightblue","lightcoral","lightcyan",
-                         "lightgoldenrodyellow","lightgray","lightgreen","lightgrey",
-                         "lightpink","lightsalmon","lightseagreen","lightskyblue",
-                         "lightslategray","lightslategrey","lightsteelblue","lightyellow",
-                         "lime","limegreen","linen","magenta","maroon","mediumaquamarine",
-                         "mediumblue","mediumorchid","mediumpurple","mediumseagreen",
-                         "mediumslateblue","mediumspringgreen","mediumturquoise",
-                         "mediumvioletred","midnightblue","mintcream","mistyrose",
-                         "moccasin","navajowhite","navy","oldlace","olive","olivedrab",
-                         "orange","orangered","orchid","palegoldenrod","palegreen",
-                         "paleturquoise","palevioletred","papayawhip","peachpuff","peru",
-                         "pink","plum","powderblue","purple","red","rosybrown","royalblue",
-                         "saddlebrown","salmon","sandybrown","seagreen","seashell",
-                         "sienna","silver","skyblue","slateblue","slategray","slategrey",
-                         "snow","springgreen","steelblue","tan","teal","thistle","tomato",
-                         "turquoise","violet","wheat","white","whitesmoke","yellow",
-                         "yellowgreen"];
+        let ext_names = [
+            "aliceblue",
+            "antiquewhite",
+            "aqua",
+            "aquamarine",
+            "azure",
+            "beige",
+            "bisque",
+            "black",
+            "blanchedalmond",
+            "blue",
+            "blueviolet",
+            "brown",
+            "burlywood",
+            "cadetblue",
+            "chartreuse",
+            "chocolate",
+            "coral",
+            "cornflowerblue",
+            "cornsilk",
+            "crimson",
+            "cyan",
+            "darkblue",
+            "darkcyan",
+            "darkgoldenrod",
+            "darkgray",
+            "darkgreen",
+            "darkgrey",
+            "darkkhaki",
+            "darkmagenta",
+            "darkolivegreen",
+            "darkorange",
+            "darkorchid",
+            "darkred",
+            "darksalmon",
+            "darkseagreen",
+            "darkslateblue",
+            "darkslategray",
+            "darkslategrey",
+            "darkturquoise",
+            "darkviolet",
+            "deeppink",
+            "deepskyblue",
+            "dimgray",
+            "dimgrey",
+            "dodgerblue",
+            "firebrick",
+            "floralwhite",
+            "forestgreen",
+            "fuchsia",
+            "gainsboro",
+            "ghostwhite",
+            "gold",
+            "goldenrod",
+            "gray",
+            "green",
+            "greenyellow",
+            "grey",
+            "honeydew",
+            "hotpink",
+            "indianred",
+            "indigo",
+            "ivory",
+            "khaki",
+            "lavender",
+            "lavenderblush",
+            "lawngreen",
+            "lemonchiffon",
+            "lightblue",
+            "lightcoral",
+            "lightcyan",
+            "lightgoldenrodyellow",
+            "lightgray",
+            "lightgreen",
+            "lightgrey",
+            "lightpink",
+            "lightsalmon",
+            "lightseagreen",
+            "lightskyblue",
+            "lightslategray",
+            "lightslategrey",
+            "lightsteelblue",
+            "lightyellow",
+            "lime",
+            "limegreen",
+            "linen",
+            "magenta",
+            "maroon",
+            "mediumaquamarine",
+            "mediumblue",
+            "mediumorchid",
+            "mediumpurple",
+            "mediumseagreen",
+            "mediumslateblue",
+            "mediumspringgreen",
+            "mediumturquoise",
+            "mediumvioletred",
+            "midnightblue",
+            "mintcream",
+            "mistyrose",
+            "moccasin",
+            "navajowhite",
+            "navy",
+            "oldlace",
+            "olive",
+            "olivedrab",
+            "orange",
+            "orangered",
+            "orchid",
+            "palegoldenrod",
+            "palegreen",
+            "paleturquoise",
+            "palevioletred",
+            "papayawhip",
+            "peachpuff",
+            "peru",
+            "pink",
+            "plum",
+            "powderblue",
+            "purple",
+            "red",
+            "rosybrown",
+            "royalblue",
+            "saddlebrown",
+            "salmon",
+            "sandybrown",
+            "seagreen",
+            "seashell",
+            "sienna",
+            "silver",
+            "skyblue",
+            "slateblue",
+            "slategray",
+            "slategrey",
+            "snow",
+            "springgreen",
+            "steelblue",
+            "tan",
+            "teal",
+            "thistle",
+            "tomato",
+            "turquoise",
+            "violet",
+            "wheat",
+            "white",
+            "whitesmoke",
+            "yellow",
+            "yellowgreen",
+        ];
         for name in ext_names.iter() {
             assert_eq!(Color::name(name).is_some(), true);
         }
@@ -797,13 +953,13 @@ mod tests {
         let red = Color::name("red").unwrap();
         assert_eq!(Color::from("#ff0000"), red);
         assert_eq!(Color::from("#ff0000".to_string()), red);
-        assert_eq!(Color::from((255,0,0)), red);
-        assert_eq!(Color::from(&[255,0,0]), red);
-        assert_eq!(Color::from(&[1.,0.,0.]), red);
-        let rgb = vec![1.,0.,0.];
+        assert_eq!(Color::from((255, 0, 0)), red);
+        assert_eq!(Color::from(&[255, 0, 0]), red);
+        assert_eq!(Color::from(&[1., 0., 0.]), red);
+        let rgb = vec![1., 0., 0.];
         assert_eq!(Color::from(&rgb), red);
         assert_eq!(Color::from(rgb), red);
-        let rgb = vec![1.0f32,0.,0.];
+        let rgb = vec![1.0f32, 0., 0.];
         assert_eq!(Color::from(&rgb), red);
         assert_eq!(Color::from(rgb), red);
         assert_eq!(Color::from("red"), red);
@@ -813,10 +969,10 @@ mod tests {
     #[test]
     fn test_into() {
         let red = Color::name("red").unwrap();
-        assert_eq!(red, (255,0,0).into());
+        assert_eq!(red, (255, 0, 0).into());
         assert_eq!(red, "red".into());
         assert_eq!(red, "#ff0000".into());
-        assert_eq!(red, (1.0,0.0,0.0).into());
+        assert_eq!(red, (1.0, 0.0, 0.0).into());
     }
     #[test]
     fn test_display() {
@@ -824,15 +980,15 @@ mod tests {
         assert_eq!(format!("{}", red), "(1.000, 0.000, 0.000, 1.000)");
     }
 
-    fn assert_tol(a: (f64,f64,f64), b: (f64,f64,f64), tol: f64) {
-        if (a.0-b.0).abs() > tol {
-            assert_eq!(a,b);
+    fn assert_tol(a: (f64, f64, f64), b: (f64, f64, f64), tol: f64) {
+        if (a.0 - b.0).abs() > tol {
+            assert_eq!(a, b);
         }
-        if (a.1-b.1).abs() > tol {
-            assert_eq!(a,b);
+        if (a.1 - b.1).abs() > tol {
+            assert_eq!(a, b);
         }
-        if (a.2-b.2).abs() > tol {
-            assert_eq!(a,b);
+        if (a.2 - b.2).abs() > tol {
+            assert_eq!(a, b);
         }
     }
     /*
@@ -850,14 +1006,14 @@ mod tests {
         for r in 0..256 {
             for g in 0..256 {
                 for b in 0..256 {
-                    let rf = r as f64/ 255.0;
-                    let gf = g as f64/ 255.0;
-                    let bf = b as f64/ 255.0;
+                    let rf = r as f64 / 255.0;
+                    let gf = g as f64 / 255.0;
+                    let bf = b as f64 / 255.0;
 
-                    let (y,i,q) = rgb2yiq(rf,gf,bf);
-                    let (r0,g0,b0) = yiq2rgb(y,i,q);
+                    let (y, i, q) = rgb2yiq(rf, gf, bf);
+                    let (r0, g0, b0) = yiq2rgb(y, i, q);
                     //cprint((rf,gf,bf),(y,i,q),(r0,g0,b0),(r,g,b));
-                    assert_tol((rf,gf,bf),(r0,g0,b0), 1e-13);
+                    assert_tol((rf, gf, bf), (r0, g0, b0), 1e-13);
                 }
             }
         }
@@ -868,14 +1024,14 @@ mod tests {
         for r in 0..256 {
             for g in 0..256 {
                 for b in 0..256 {
-                    let rf = r as f64/ 255.0;
-                    let gf = g as f64/ 255.0;
-                    let bf = b as f64/ 255.0;
+                    let rf = r as f64 / 255.0;
+                    let gf = g as f64 / 255.0;
+                    let bf = b as f64 / 255.0;
 
-                    let (h,s,l) = rgb2hsl(rf,gf,bf);
-                    let (r0,g0,b0) = hsl2rgb(h,s,l);
+                    let (h, s, l) = rgb2hsl(rf, gf, bf);
+                    let (r0, g0, b0) = hsl2rgb(h, s, l);
                     //cprint((rf,gf,bf),(h,s,l),(r0,g0,b0),(r,g,b));
-                    assert_tol((rf,gf,bf),(r0,g0,b0), 1e-13);
+                    assert_tol((rf, gf, bf), (r0, g0, b0), 1e-13);
                 }
             }
         }
@@ -884,38 +1040,48 @@ mod tests {
     #[test]
     #[ignore]
     fn hsv() {
-        assert_eq!(rgb2hsv(0.,0.,0.), (0.,0.,0.));
-        assert_eq!(rgb2hsv(1.,0.,0.), (0.,1.,1.));
-        assert_eq!(rgb2hsv(0.,1.,0.), (120.,1.,1.));
-        assert_eq!(rgb2hsv(0.,0.,1.), (240.,1.,1.));
+        assert_eq!(rgb2hsv(0., 0., 0.), (0., 0., 0.));
+        assert_eq!(rgb2hsv(1., 0., 0.), (0., 1., 1.));
+        assert_eq!(rgb2hsv(0., 1., 0.), (120., 1., 1.));
+        assert_eq!(rgb2hsv(0., 0., 1.), (240., 1., 1.));
 
-        assert_eq!(rgb2hsv(1.,1.,0.), (60.,1.,1.));
-        assert_eq!(rgb2hsv(1.,0.,1.), (300.,1.,1.));
-        assert_eq!(rgb2hsv(0.,1.,1.), (180.,1.,1.));
+        assert_eq!(rgb2hsv(1., 1., 0.), (60., 1., 1.));
+        assert_eq!(rgb2hsv(1., 0., 1.), (300., 1., 1.));
+        assert_eq!(rgb2hsv(0., 1., 1.), (180., 1., 1.));
 
-        assert_eq!(rgb2hsv(1.0,0.0,std::f64::EPSILON), (360.,1.0,1.0));
+        assert_eq!(rgb2hsv(1.0, 0.0, std::f64::EPSILON), (360., 1.0, 1.0));
 
-        assert_eq!(rgb2hsv(1./255.,1./255.,2./255.), (240.,0.5, 2./255.));
-        assert_eq!(hsv2rgb(240.,0.5,2./255.), (1./255.,1./255., 2./255.));
+        assert_eq!(
+            rgb2hsv(1. / 255., 1. / 255., 2. / 255.),
+            (240., 0.5, 2. / 255.)
+        );
+        assert_eq!(
+            hsv2rgb(240., 0.5, 2. / 255.),
+            (1. / 255., 1. / 255., 2. / 255.)
+        );
 
-        assert_eq!(rgb2hsv(1./255.,0./255.,1./255.), (300.,1., 1./255.));
-        assert_eq!(hsv2rgb(300.,1.0,1./255.), (1./255.,0./255., 1./255.));
+        assert_eq!(
+            rgb2hsv(1. / 255., 0. / 255., 1. / 255.),
+            (300., 1., 1. / 255.)
+        );
+        assert_eq!(
+            hsv2rgb(300., 1.0, 1. / 255.),
+            (1. / 255., 0. / 255., 1. / 255.)
+        );
 
         for r in 0..256 {
             for g in 0..256 {
                 for b in 0..256 {
-                    let rf = r as f64/ 255.0;
-                    let gf = g as f64/ 255.0;
-                    let bf = b as f64/ 255.0;
+                    let rf = r as f64 / 255.0;
+                    let gf = g as f64 / 255.0;
+                    let bf = b as f64 / 255.0;
 
-                    let (h,s,v) = rgb2hsv(rf,gf,bf);
-                    let (r0,g0,b0) = hsv2rgb(h,s,v);
+                    let (h, s, v) = rgb2hsv(rf, gf, bf);
+                    let (r0, g0, b0) = hsv2rgb(h, s, v);
                     //cprint((rf,gf,bf),(h,s,v),(r0,g0,b0),(r,g,b));
-                    assert_tol((rf,gf,bf),(r0,g0,b0), 1e-13);
+                    assert_tol((rf, gf, bf), (r0, g0, b0), 1e-13);
                 }
             }
         }
     }
 }
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ use std::{
 pub type Colour = Color;
 
 /// Color value
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Color {
     /// Red component [0,1]
     pub red: f64,
@@ -386,15 +386,6 @@ impl From<Vec<f32>> for Color {
     fn from(c: Vec<f32>) -> Color {
         let c64: Vec<_> = c.into_iter().map(f64::from).collect();
         Color::from(&c64)
-    }
-}
-
-impl PartialEq for Color {
-    fn eq(&self, other: &Color) -> bool {
-        self.red == other.red
-            && self.blue == other.blue
-            && self.green == other.green
-            && self.alpha == other.alpha
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,6 @@ fn parse_name_hex(line: &str) -> Option<(String, Color)> {
 ///      name  #hex-value
 ///      r255 g255 b255 name
 ///   Lines beginning with # are ignored
-
 pub fn read_buffer<T>(buf: T) -> Vec<(String, Color)>
 where
     T: BufRead,

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -1,4 +1,3 @@
-
 extern crate tint;
 
 fn by_rgb(a: &str, b: &str) -> std::cmp::Ordering {
@@ -15,7 +14,7 @@ fn by_hsv(a: &str, b: &str) -> std::cmp::Ordering {
 #[test]
 fn sort_rgb() {
     let mut keys = tint::names();
-    keys.sort_by(|a, b| by_rgb(a,b));
+    keys.sort_by(|a, b| by_rgb(a, b));
     for k in keys.iter() {
         let c = tint::Color::from(k);
         println!("{:20}: {} {}", k, c, c.to_hex());
@@ -25,10 +24,18 @@ fn sort_rgb() {
 #[test]
 fn sort_hue() {
     let mut keys = tint::names();
-    keys.sort_by(|a, b| by_hsv(a,b));
+    keys.sort_by(|a, b| by_hsv(a, b));
     for k in keys.iter() {
         let c = tint::Color::from(k);
         let hsv = c.to_hsv();
-        println!("{:20}: {} {} {:.3} {:.3} {:.3}", k, c, c.to_hex(), hsv.0,hsv.1,hsv.2);
+        println!(
+            "{:20}: {} {} {:.3} {:.3} {:.3}",
+            k,
+            c,
+            c.to_hex(),
+            hsv.0,
+            hsv.1,
+            hsv.2
+        );
     }
 }

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -1,4 +1,4 @@
-extern crate tint;
+use tint;
 
 fn by_rgb(a: &str, b: &str) -> std::cmp::Ordering {
     let ca = tint::Color::from(a);

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -1,4 +1,3 @@
-
 extern crate tint;
 
 #[test]
@@ -7,7 +6,10 @@ fn table() {
     println!("|----------------------|--------------------------------------------------------|");
     for name in tint::names() {
         let color = tint::Color::from(&name);
-        println!("| {name:20} | ![{hex}](https://placehold.it/100x15/{hex}?text=+) |", name=name, hex=color.to_hex());
+        println!(
+            "| {name:20} | ![{hex}](https://placehold.it/100x15/{hex}?text=+) |",
+            name = name,
+            hex = color.to_hex()
+        );
     }
 }
-

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -1,4 +1,4 @@
-extern crate tint;
+use tint;
 
 #[test]
 fn table() {


### PR DESCRIPTION
 * 7922baf Cleanup code using cargo fmt
 * 2e0cbfb use rust 2018 and run: cargo fix --edition-idioms
 * 053ac31 bump lazy_static to version 1.3.0
 * 9d54e4f manually apply cleanup suggestions from clippy
 * ffc0e7d manual code cleanup
 * 567cf27 derive PartialEq instead of implemeting it
 * 574c085 remove rust 2015 specific code from README.md
 * 257ffff allow clippy lint many_single_char_names in some functions
 * 7c97303 move version to 1.0.2